### PR TITLE
Fair keep selection

### DIFF
--- a/keep.tex
+++ b/keep.tex
@@ -637,7 +637,9 @@ random beacon design, based on a concept they call threshold relay
   $G_{registered}$. $G_i$ signs $r_0$ and publishes the
   result, $r_1 = threshold(r_0, s_{0\rightarrow{t}})$ where
   $s_{0\rightarrow{t}}$ is the minimal shares necessary the the group
-  to produce a signature. \\
+  to produce a signature. Note that $threshold(...)$ must be a
+  deterministic signature scheme to avoid share withholding attacks
+  leading to a biased output. \\
   \textbf{Iteration:} & Each block published on the chain will include
   a signature from $G_{registered}$ of the random value $r_i$. As the
   chain grows, the signing threshold groups will change based on
@@ -691,6 +693,11 @@ invalid. Each iteration, a new signing group is chosen by the previous
 iteration's random value. As all groups sign the previous iteration's
 value, if a signature that's chosen is invalid, the signature from the
 next group in line can be chosen instead.
+
+Importantly, the threshold signature scheme needs to be deterministic
+to prevent individual shareholders from biasing the signature outcome
+in their favor. BLS signatures \cite{BLS} have been used in related
+work.
 
 \subsubsection{Keep selection group}
 

--- a/keep.tex
+++ b/keep.tex
@@ -494,6 +494,7 @@ To counter this issue, keep providers will need a protocol to
 optionally re-negotiate fees for a running keep.
 
 \subsection{Concerns with active attacks}
+\label{activeAttacks}
 
 Existing open-source sMPC frameworks, such as VIFF \cite{viff}, are
 secure against active attacks in the presence of a ¾ supermajority of
@@ -518,7 +519,7 @@ First, keep providers will be required to prove their holdings in a
 token native to the system. Significant disruption of the network
 should lead to a drop in the value of the token, incentivizing
 provider honesty, lest they devalue their holdings. This scheme also
-provides resistance to Sybil attacks- an active attacker would need to
+provides resistance to Sybil attacks--- an active attacker would need to
 obtain an outsize portion of all tokens locked up by keep providers to
 ensure their overwhelming selection backing new keeps.
 
@@ -534,7 +535,17 @@ To bring these components together into a functional network,
 initially built against the Ethereum blockchain, we'll introduce a few
 more ideas.
 
+\subsection{The Keep network token}
+
+The native network token will be required for providers to
+participate. Requiring a native token, rather than the underlying
+blockchain's currency, means providers will suffer from negative
+externalities in the presence of malicious behavior
+\ref{activeAttacks}, and staking strengthens the system against Sybil
+attacks \ref{fairKeepSelection}.
+
 \subsection{The keep market}
+\label{fairKeepSelection}
 
 Different keep types will naturally incur different costs, and offer
 differing guarantees and functionality to contract developers. At a
@@ -542,17 +553,6 @@ given time, the capacity available on the keep network will also be
 limited capacity.. For this reason, a market will need to be developed
 that matches keep providers to contracts based on bids for price per
 block, price per operation, and required functionality.
-
-\subsection{The Keep network token}
-
-The native network token will be required for providers to participate
-in the keep market. Requiring a native token, rather than the
-underlying blockchain's currency, means providers will suffer from
-negative externalities in the presence of malicious behavior.
-
-Keep operations can be paid for with the native token, or with the
-underlying blockchain's currency, based on the keep market.
-
 \subsection{The result registry}
 
 Keeps will offer a number of methods to publish to the public

--- a/keep.tex
+++ b/keep.tex
@@ -560,15 +560,16 @@ staking also strengthens the system against Sybil attacks
 \subsection{Ensuring fair keep selection}
 \label{fairKeepSelection}
 
-Initially, the network was meant to include an on-chain marketplace to
-match contracts requesting keeps and keep providers.
+Contracts requesting keeps and keep providers need to be matched. An
+ideal system would enable price discovery, incentivizing new providers
+to join if capacity is low, across different keep types.
 
-Markets solve a number of issues, including keep price discovery
-and capacity provisioning. Unfortunately, on-chain marketplaces also mean the
-provider matching process can be gamed. A clever attacker could
+This matching problem is a great fit for a market. Unfortunately,
+on-chain markets are a difficult problem, prone to complexity, miner
+frontrunning, and orderbook manipulation. A clever attacker could
 manipulate a market, giving them an unfair advantage to be chosen for
-a particular keep. Essentially, an ask/bid market opens the network to
-Sybil attacks.
+a particular keep. Essentially, an two-sided market would expose the
+network to Sybil attacks.
 
 In lieu of a market, we need a fair keep selection mechanism.
 
@@ -682,14 +683,14 @@ and correspond to a newly generated threshold private key, split
 across the participants.
 
 As providers join the network, they will form threshold groups. These
-groups will then sign a piece of random data from a trusted party,
-bootstrapping the relay. The resulting signature provides the random
-data for the next iteration, which can be verified by the rest of the
-network participants and rejected if invalid. Each iteration, a new
-signing group is chosen by the previous iteration's random value. As
-all groups sign the previous iteration's value, if a signature that's
-chosen is invalid, the signature from the next group in line can be
-chosen instead.
+groups will then sign a piece of random data, initially provided by
+early network contributors, to bootstrap the relay. The resulting
+signature provides the random data for the next iteration, which can
+be verified by the rest of the network participants and rejected if
+invalid. Each iteration, a new signing group is chosen by the previous
+iteration's random value. As all groups sign the previous iteration's
+value, if a signature that's chosen is invalid, the signature from the
+next group in line can be chosen instead.
 
 \subsubsection{Keep selection group}
 

--- a/keep.tex
+++ b/keep.tex
@@ -615,7 +615,62 @@ Fortunately, the Dfinity team has solved these issues with their
 random beacon design, based on a concept they call threshold relay
 \cite{thresholdRelay}.
 
-\subsection{The result registry}
+\subsubsection{Threshold relay}
+
+This work relies on the idea of threshold secret sharing schemes---
+secret sharing schemes that retain confidentiality up to some
+threshold $t$ of honest actors.
+
+Threshold signatures are a related idea. A threshold signature is a
+signature across $n$ parties that requires some minimum $t$ actively
+participating to sign. It's a similar idea to "multi-sig" as deployed
+in cryptocurrencies today.
+
+Traditional multi-sig, however, requires a smart contract on the
+blockchain to validate each signature and release funds. Threshold
+signature schemes actually require a threshold $t$ to construct a
+signature at all, removing a layer of complexity and coordination
+between parties.
+
+The use of threshold signatures means a number of participating
+signers in a signing group can be unavailable, and the signature will
+still succeed in the presence of $t$ functioning signers. This
+provides some of our beacon's required resilience in the face of
+failing or misbehaving nodes.
+
+If threshold signatures sound familiar, it might be because they're a
+core functionality keeps provide. For example, a keep signing a
+Bitcoin transaction does so using threshold ECDSA.
+
+A threshold relay is a way to chain threshold signatures to create a
+random beacon. Participants in a threshold relay form threshold
+groups. These groups generate new public keys that identify the group
+and correspond to a newly generated threshold private key, split
+across the participants.
+
+As providers join the network, they will form threshold groups. These
+groups will then sign a piece of random data from a trusted party,
+bootstrapping the relay. The resulting signature provides the random
+data for the next iteration, which can be verified by the rest of the
+network participants and rejected if invalid. Each iteration, a new
+signing group is chosen by the previous iteration's random value. As
+all groups sign the previous iteration's value, if a signature that's
+chosen is invalid, the signature from the next group in line can be
+chosen instead.
+
+\subsubsection{Keep selection group}
+
+Our threshold relay system will be composed of keep providers seeking
+to be chosen to back a new keep, capturing the fees from that keep.
+
+Each block will include a random signature, published by the nominated
+keep selection group. Any keeps that require new nodes will have their
+providers chosen randomly, using the beacon value from the last block.
+
+In this way, we can ensure fair chances to all staked keep providers,
+keeping the cost of a Sybil attack high.
+
+\section{The result registry}
 
 Keeps will offer a number of methods to publish to the public
 blockchain. In the case where keeps publish to a smart contract
@@ -623,7 +678,8 @@ provided by the keep owner, coordination is simple. In uses that don't
 have a natural contract to communicate with, a result registry will be
 provided as a default to simplify keep and owner coordination.
 
-\section{Applications} \label{applications}
+\section{Applications}
+\label{applications}
 
 \subsection{Dead man switch}
 

--- a/keep.tex
+++ b/keep.tex
@@ -612,7 +612,8 @@ between participants, slowing down the key generation process and
 providing a large surface for communication failure.
 
 Fortunately, the Dfinity team has solved these issues with their
-random beacon design, based on a concept they call threshold relay.
+random beacon design, based on a concept they call threshold relay
+\cite{thresholdRelay}.
 
 \subsection{The result registry}
 

--- a/keep.tex
+++ b/keep.tex
@@ -617,6 +617,39 @@ random beacon design, based on a concept they call threshold relay
 
 \subsubsection{Threshold relay}
 
+\begin{table*}[t]
+  \centering
+  \begin{tabular}{|rp{10cm}|}
+  \hline
+  \multicolumn{2}{|c|}{\textit{Iterative threshold signatures for
+  randomness on existing chains}} \\
+  \textbf{Registration:} & As providers join the network, they
+  register with at least one threshold group $G_i$ of all groups $G$,
+  generating a share of the group's private key, $s_i$. Threshold groups are
+  capped at $c$ members, and may intersect. Groups that have reached
+  this maximum size publish their public key to the blockchain. We'll
+  designate such groups as $G_{registered}$. \\
+  \textbf{Trusted setup:} & A trusted party posts a random value
+  $r_0$ to the blockchain as the beacon's first output. \\
+  \textbf{Bootstrapping:} & $mod(r_{0}, |G_{registered}|)$ is
+  used to select a registered threshold group, $G_i$, from
+  $G_{registered}$. $G_i$ signs $r_0$ and publishes the
+  result, $r_1 = threshold(r_0, s_{0\rightarrow{t}})$ where
+  $s_{0\rightarrow{t}}$ is the minimal shares necessary the the group
+  to produce a signature. \\
+  \textbf{Iteration:} & Each block published on the chain will include
+  a signature from $G_{registered}$ of the random value $r_i$. As the
+  chain grows, the signing threshold groups will change based on
+  provider availability. If any group is non-responsive up to its
+  threshold $t$, the group is removed from $G_{registered}$. \\
+  \textbf{Failure:} & Each iteration is an opportunity for a
+  group to fail to generate a valid signature. If a group $G_i$ fails
+  to sign the last iteration's random value, $G_{i+1}$ will be used
+  instead. \\
+  \hline
+\end{tabular}
+\end{table*}
+
 This work relies on the idea of threshold secret sharing schemes---
 secret sharing schemes that retain confidentiality up to some
 threshold $t$ of honest actors.

--- a/keep.tex
+++ b/keep.tex
@@ -531,28 +531,89 @@ deposit is forfeit to competing nodes.
 
 \section{High-level network design}
 
-To bring these components together into a functional network,
-initially built against the Ethereum blockchain, we'll introduce a few
-more ideas.
+Deploying sMPC-based privacy on a public blockchain requires
+supporting infrastructure. To build a functional privacy network
+against Ethereum, our first target blockchain, we'll introduce
+components to ensure fair keep node selection, report results, and
+incentivize network actors.
 
 \subsection{The Keep network token}
 
-The native network token will be required for providers to
-participate. Requiring a native token, rather than the underlying
-blockchain's currency, means providers will suffer from negative
-externalities in the presence of malicious behavior
-\ref{activeAttacks}, and staking strengthens the system against Sybil
-attacks \ref{fairKeepSelection}.
+The native network token, \textit{KEEP}, will be required for
+providers to participate.
 
-\subsection{The keep market}
+To be chosen to provide a node for a new keep, a provider must lock up
+a minimum stake in KEEP tokens, using a shared staking contract.
+
+At any time, a provider can choose to retrieve their stake--- for
+example, to liquidate their position. All withdrawals, however, will
+be subject to a two-week waiting period to disincentive providers from
+quickly staking and withdrawing their position, which could have
+adverse effects on running keeps and fair keep selection.
+
+Requiring a native token, rather than the underlying blockchain's
+currency, means providers will suffer from negative externalities in
+the presence of malicious behavior \ref{activeAttacks}. This sort of
+staking also strengthens the system against Sybil attacks
+\ref{fairKeepSelection}.
+
+\subsection{Ensuring fair keep selection}
 \label{fairKeepSelection}
 
-Different keep types will naturally incur different costs, and offer
-differing guarantees and functionality to contract developers. At a
-given time, the capacity available on the keep network will also be
-limited capacity.. For this reason, a market will need to be developed
-that matches keep providers to contracts based on bids for price per
-block, price per operation, and required functionality.
+Initially, the network was meant to include an on-chain marketplace to
+match contracts requesting keeps and keep providers.
+
+Markets solve a number of issues, including keep price discovery
+and capacity provisioning. Unfortunately, on-chain marketplaces also mean the
+provider matching process can be gamed. A clever attacker could
+manipulate a market, giving them an unfair advantage to be chosen for
+a particular keep. Essentially, an ask/bid market opens the network to
+Sybil attacks.
+
+In lieu of a market, we need a fair keep selection mechanism.
+
+\subsubsection{Random beacons}
+
+The best way to select providers for a new keep is with a fair coin
+toss. Unfortunately, Ethereum only supports deterministic functions.
+Contracts that require a random number often rely on a trusted oracle.
+
+A system is only as decentralized as its most centralized component.
+Relying on a trusted third party for such a core function of the
+project isn't an acceptable risk.
+
+Instead, we can utilize our keep providers as a decentralized source
+of entropy. All staked providers can be required to take part in the
+random number generation process.
+
+There are a few design considerations for such a system
+\begin{itemize}
+  \item Providers can't be allowed an unfair advantage over each other
+      in the node selection process.
+  \item Each block on the public chain will require at least one
+      random number of sufficient size. Today's Ethereum block time is
+      25 seconds, but that will likely change significantly in the
+      future. The RNG process needs to be fast enough to support much
+      shorter block time, if necessary.
+  \item RNG needs to be resilient to node failure. Failure in
+      production means no new keeps can be created, so resilience
+      to partitions between providers as well as against active denial
+      of service attacks is desirable.
+  \item While not a hard system requirement, providing the Ethereum
+      network with a trusted source of randomness will also be a great
+      boon to other projects.
+\end{itemize}
+
+Most distributed key generation schemes are too slow or prone to
+manipulation to be considered. Any scheme we choose should provide
+good performance, regardless of the number of particating providers.
+Instead, most generation schemes require rounds of communication
+between participants, slowing down the key generation process and
+providing a large surface for communication failure.
+
+Fortunately, the Dfinity team has solved these issues with their
+random beacon design, based on a concept they call threshold relay.
+
 \subsection{The result registry}
 
 Keeps will offer a number of methods to publish to the public

--- a/references.bib
+++ b/references.bib
@@ -230,3 +230,13 @@
     howpublished={\url{https://dfinity.network/pdfs/viewer.html?file=../library/threshold-relay-blockchain-stanford.pdf}},
     note={Accessed: 2017-09-02}
 }
+
+@article{BLS,
+    title={Short signatures from the Weil pairing},
+    author={Boneh, Dan and Lynn, Ben and Shacham, Hovav},
+    journal={Advances in Cryptology—ASIACRYPT 2001},
+    pages={514--532},
+    year={2001},
+    publisher={Springer},
+    note={\url{https://www.iacr.org/archive/asiacrypt2001/22480516.pdf} Accessed: 2017-09-06}
+}

--- a/references.bib
+++ b/references.bib
@@ -223,3 +223,10 @@
     howpublished={\url{https://en.wikipedia.org/wiki/Commitment_scheme}},
     note={Accessed: 2017-09-02}
 }
+
+@misc{thresholdRelay,
+    title={Threshold relay: how to achieve near-instant finality in
+        public blockchains using a VRF},
+    howpublished={\url{https://dfinity.network/pdfs/viewer.html?file=../library/threshold-relay-blockchain-stanford.pdf}},
+    note={Accessed: 2017-09-02}
+}


### PR DESCRIPTION
Markets for keep node selection open a vector for Sybil attacks and denial of service. Instead, we'll use a fair selection process based on RNG methods originally proposed by the Dfinity team