### PR TITLE
Russian hyphenation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ orbs:
     executors:
       default:
         docker:
-          - image: keepnetwork/texlive:2
+          - image: keepnetwork/texlive:4
     jobs:
       make_and_store:
         parameters:

--- a/keep.ru.tex
+++ b/keep.ru.tex
@@ -1,12 +1,12 @@
 %% Based on the style files for ACL-2015
 
-\documentclass[english,main=russian,11pt]{article}
+\documentclass[english,11pt]{article}
 \usepackage[hidelinks]{hyperref}
 \usepackage{acl2015}
 \usepackage[numbers]{natbib}
 \usepackage{fancyhdr}
 \usepackage[T1,T2A,OT1]{fontenc} 
-\usepackage[russian,english]{babel}
+\usepackage[english,russian]{babel}
 \usepackage[utf8]{inputenc}
 
 \title{The Keep Network:\protect\\Приватный Слой для Паблик Блокчейнов}


### PR DESCRIPTION
Does what it says! A new build of `keepnetwork/texlive` includes Russian
hyphenation rules. It also prebuilds some fonts for us. I sneaked in a fix for
some babel warnings during the build.